### PR TITLE
Compatibility with GMAP versions 2016-05+

### DIFF
--- a/scripts/process_GMAP_alignments_gff3_chimeras_ok.pl
+++ b/scripts/process_GMAP_alignments_gff3_chimeras_ok.pl
@@ -88,7 +88,14 @@ main: {
 
 	my $cmd = "gmap -D $genomeBaseDir -d $genomeDir $transcriptDB -f $format -n $num_gmap_top_hits -x 50 -t $CPU -B 5 ";
 	if ($max_intron) {
-		$cmd .= " --intronlength=$max_intron ";
+		my $gmapv=`gmap --version 2>&1 | head -1`;
+		chomp($gmapv);
+		$gmapv=~/GMAP\s+version\s+(\d{4})-(\d{2})-.*/;
+		if( ($1 == 2016 && $2 >= 5) || $1 > 2016){
+			$cmd .= " --max-intronlength-middle=$max_intron --max-intronlength-ends=$max_intron ";
+		}else{
+			$cmd .= " --intronlength=$max_intron ";
+		}
 	}
 	
 	&process_cmd($cmd);


### PR DESCRIPTION
In gmap version 2016-05 new arguments [were introduced](http://research-pub.gene.com/gmap/archive.html).
>Added separate flags in GMAP for controlling intron length of end introns separately from middle introns. Flag names are now --max-intronlength-middle (previously --intronlength) and --max-intronlength-ends

This patch is to evaluate gmap version and to prepare arguments of gmap call accordingly.