### PR TITLE
Add support for SQLite

### DIFF
--- a/PerlLib/Ath1_cdnas.pm
+++ b/PerlLib/Ath1_cdnas.pm
@@ -498,7 +498,7 @@ sub load_CDNA_alignment_obj {
         
     
     ## insert row in cdna_link
-    my $query = "insert align_link (align_acc, cdna_info_id, prog, validate, aligned_orient, spliced_orient, num_segments) values (?,?,?,?,?,?,?)";
+    my $query = "insert into align_link (align_acc, cdna_info_id, prog, validate, aligned_orient, spliced_orient, num_segments) values (?,?,?,?,?,?,?)";
     &RunMod($dbproc, 
             $query, 
             $alignment->get_acc(),
@@ -515,7 +515,7 @@ sub load_CDNA_alignment_obj {
     foreach my $segment (@segments) {
         my ($lend, $rend) = sort {$a<=>$b} $segment->get_coords();
         my ($mlend, $mrend) = sort {$a<=>$b} $segment->get_mcoords();
-        my $query = "insert alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
+        my $query = "insert into alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
         &RunMod($dbproc, $query, $align_id, $lend, $rend, $mlend, $mrend, $alignment->get_aligned_orientation(), $segment->get_per_id());
         
     }

--- a/PerlLib/Mysql_connect.pm
+++ b/PerlLib/Mysql_connect.pm
@@ -28,7 +28,12 @@ sub connect_to_db {
         confess "Error, need all method parameters (server, db, username, password) ";
     }
     
-    my $dbh = DBI->connect("DBI:mysql:$db:$server", $username, $password);
+    my $dbh;
+    if ($server eq 'SQLite') {
+        $dbh = DBI->connect("DBI:SQLite:dbname=$db", undef, undef);
+    } else {
+        $dbh = DBI->connect("DBI:mysql:$db:$server", $username, $password);
+    }
     unless (ref $dbh) {
         croak "Cannot connect to $server: $DBI::errstr";
     }
@@ -197,7 +202,7 @@ sub very_first_result_sql {
 
 sub get_last_insert_id {
     my ($dbproc) = @_;
-    my $query = "select LAST_INSERT_ID()";
+    my $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
     return (&very_first_result_sql($dbproc, $query));
 }
 

--- a/cgi-bin/PerlLib/Ath1_cdnas.pm
+++ b/cgi-bin/PerlLib/Ath1_cdnas.pm
@@ -498,7 +498,7 @@ sub load_CDNA_alignment_obj {
         
     
     ## insert row in cdna_link
-    my $query = "insert align_link (align_acc, cdna_info_id, prog, validate, aligned_orient, spliced_orient, num_segments) values (?,?,?,?,?,?,?)";
+    my $query = "insert into align_link (align_acc, cdna_info_id, prog, validate, aligned_orient, spliced_orient, num_segments) values (?,?,?,?,?,?,?)";
     &RunMod($dbproc, 
             $query, 
             $alignment->get_acc(),
@@ -515,7 +515,7 @@ sub load_CDNA_alignment_obj {
     foreach my $segment (@segments) {
         my ($lend, $rend) = sort {$a<=>$b} $segment->get_coords();
         my ($mlend, $mrend) = sort {$a<=>$b} $segment->get_mcoords();
-        my $query = "insert alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
+        my $query = "insert into alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
         &RunMod($dbproc, $query, $align_id, $lend, $rend, $mlend, $mrend, $alignment->get_aligned_orientation(), $segment->get_per_id());
         
     }

--- a/cgi-bin/check_symmetry.dbi
+++ b/cgi-bin/check_symmetry.dbi
@@ -62,11 +62,11 @@ foreach my $result (@results) {
         
         ## compare num_transcripts_A and num_transcripts_B for forward and reciprocal comparisons:
         
-        $query = "select num_transcripts_A, num_transcripts_B from splice_variation_support where sv_id = $sv_id and cdna_acc = \"$other_cdna_acc\"";
+        $query = "select num_transcripts_A, num_transcripts_B from splice_variation_support where sv_id = $sv_id and cdna_acc = '$other_cdna_acc'";
         my $result1 = &first_result_sql($dbproc, $query);
         my ($countA, $countB) = @$result1;
 
-        $query = "select num_transcripts_A, num_transcripts_B from splice_variation_support where sv_id = $sv_id_B and cdna_acc = \"$cdna_acc\"";
+        $query = "select num_transcripts_A, num_transcripts_B from splice_variation_support where sv_id = $sv_id_B and cdna_acc = '$cdna_acc'";
         my $result2 = &first_result_sql($dbproc, $query);
         my ($countA2, $countB2) = @$result2;
         

--- a/docs/AnnotationPlugins.txt
+++ b/docs/AnnotationPlugins.txt
@@ -16,7 +16,7 @@ A. Assigning a version number to the annotation which will be imported.
 
       Perform a single insert directly to this table and retrieve the auto-incremented version_id, like so:
 
-      my $query = "insert annotation_admin (date) values (now())";
+      my $query = "insert into annotation_admin (date) values (CURRENT_TIMESTAMP)";
       &Mysql_connect::RunMod($dbproc, $query);
 
       $query  = "select LAST_INSERT_ID()";

--- a/pasa_conf/pasa.CONFIG.template
+++ b/pasa_conf/pasa.CONFIG.template
@@ -5,7 +5,8 @@
 ## MySQL settings:
 
 # server actively running MySQL
-MYSQLSERVER=localhost # or server.com
+# Set to SQLite to use an SQLite database with pathname specified by MYSQLDATABASE 
+MYSQLSERVER=localhost # or server.com, or SQLite
 # Pass socket connections through Perl DBI syntax e.g. MYSQLSERVER=mysql_socket=/tmp/mysql.sock
 
 # read-write username and password

--- a/schema/cdna_alignment_sqliteschema
+++ b/schema/cdna_alignment_sqliteschema
@@ -1,123 +1,80 @@
 CREATE TABLE URL_templates (
-  url_name varchar(20) NOT NULL default '',
-  url_template varchar(255) default NULL,
-  url_var_name varchar(20) NOT NULL default '',
-  PRIMARY KEY  (url_name)
-) ;
-
---
--- Table structure for table 'URL_var_names'
---
+  url_name TEXT PRIMARY KEY,
+  url_template TEXT DEFAULT NULL,
+  url_var_name TEXT NOT NULL DEFAULT ''
+) WITHOUT ROWID;
 
 CREATE TABLE URL_var_names (
-  url_var_name varchar(20) NOT NULL default '',
-  PRIMARY KEY  (url_var_name)
-) ;
-
---
--- Table structure for table 'alignment'
---
+  url_var_name TEXT PRIMARY KEY
+) WITHOUT ROWID;
 
 CREATE TABLE alignment (
-  feat_id integer PRIMARY KEY AUTOINCREMENT,
-  align_id int(11) NOT NULL default '0',
-  lend int(11) NOT NULL default '0',
-  rend int(11) NOT NULL default '0',
-  mlend int(11) NOT NULL default '0',
-  mrend int(11) NOT NULL default '0',
-  orient char(1) default NULL,
-  per_id float default NULL
+  feat_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  align_id INTEGER NOT NULL DEFAULT 0,
+  lend INTEGER NOT NULL DEFAULT 0,
+  rend INTEGER NOT NULL DEFAULT 0,
+  mlend INTEGER NOT NULL DEFAULT 0,
+  mrend INTEGER NOT NULL DEFAULT 0,
+  orient TEXT DEFAULT NULL CHECK(orient IN ('', '+','-')),
+  per_id NUMERIC DEFAULT NULL
 ) ;
 CREATE INDEX align_idx ON alignment(align_id);
 
---
--- Table structure for table 'alt_splice_FL_compare'
---
-
 CREATE TABLE alt_splice_FL_compare (
-  row_id integer PRIMARY KEY AUTOINCREMENT,
-  template_cdna_acc varchar(50) default NULL,
-  classification varchar(250) NOT NULL default '',
-  lend int(11) NOT NULL default '0',
-  rend int(11) NOT NULL default '0',
-  orient char(1) NOT NULL default '',
-  type varchar(50) NOT NULL default ''
+  row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  template_cdna_acc TEXT DEFAULT NULL,
+  classification TEXT NOT NULL DEFAULT '',
+  lend INTEGER NOT NULL DEFAULT 0,
+  rend INTEGER NOT NULL DEFAULT 0,
+  orient TEXT DEFAULT '' CHECK(orient IN ('', '+','-')),
+  type TEXT NOT NULL DEFAULT ''
 ) ;
-
---
--- Table structure for table 'alt_splice_FL_to_FL_compare'
---
 
 CREATE TABLE alt_splice_FL_to_FL_compare (
-  row_id integer PRIMARY KEY AUTOINCREMENT,
-  template_acc varchar(50) NOT NULL default '',
-  other_acc varchar(50) NOT NULL default '',
-  diff_in_cds int(1) NOT NULL default '0',
-  frame_change int(1) NOT NULL default '0',
-  percent_prot_length float NOT NULL default '0',
-  num_variations int(11) NOT NULL default '0',
-  same_frame_exists int(1) NOT NULL default '0'
+  row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  template_acc TEXT NOT NULL DEFAULT '',
+  other_acc TEXT NOT NULL DEFAULT '',
+  diff_in_cds BOOLEAN NOT NULL CHECK(diff_in_cds IN(0,1)),
+  frame_change BOOLEAN NOT NULL DEFAULT 0 CHECK(frame_change IN(0,1)),
+  percent_prot_length NUMERIC NOT NULL DEFAULT 0,
+  num_variations INTEGER NOT NULL DEFAULT 0,
+  same_frame_exists BOOLEAN NOT NULL DEFAULT 0 CHECK(frame_change IN(0,1))
 ) ;
-
---
--- Table structure for table 'alt_splice_link'
---
 
 CREATE TABLE alt_splice_link (
-  sv_id_A int(11) NOT NULL default '0',
-  sv_id_B int(11) NOT NULL default '0',
-  UNIQUE (sv_id_A,sv_id_B)
-) ;
+  sv_id_A INTEGER,
+  sv_id_B INTEGER,
+  PRIMARY KEY (sv_id_A,sv_id_B)
+) WITHOUT ROWID;
 CREATE INDEX sv_idx_B ON alt_splice_link(sv_id_B);
 
---
--- Table structure for table 'alt_splice_token_assignment'
---
-
 CREATE TABLE alt_splice_token_assignment (
-  cdna_acc varchar(250) NOT NULL default '',
-  token_id int(11) NOT NULL default '0'
+  cdna_acc TEXT NOT NULL DEFAULT '',
+  token_id INTEGER NOT NULL DEFAULT 0
 ) ;
-
---
--- Table structure for table 'alt_splice_tokens'
---
 
 CREATE TABLE alt_splice_tokens (
-  token_id integer PRIMARY KEY AUTOINCREMENT,
-  alt_splice_token varchar(250) NOT NULL default ''
+  token_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  alt_splice_token TEXT NOT NULL DEFAULT ''
 ) ;
-
---
--- Table structure for table 'annotation_admin'
---
 
 CREATE TABLE annotation_admin (
-  version_id integer PRIMARY KEY AUTOINCREMENT,
-  date datetime NOT NULL
+  version_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  date DATETIME NOT NULL CHECK(date IS datetime(date))
 ) ;
-
---
--- Table structure for table 'annotation_compare'
---
 
 CREATE TABLE annotation_compare (
-  compare_id integer PRIMARY KEY AUTOINCREMENT,
-  date datetime NOT NULL,
-  annotation_version integer NOT NULL default '0',
-  CHECK(annotation_version >= 0)
+  compare_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  date DATETIME NOT NULL CHECK(date IS datetime(date)),
+  annotation_version INTEGER NOT NULL DEFAULT 0 CHECK(annotation_version >= 0)
 ) ;
 
---
--- Table structure for table 'annotation_link'
---
-
 CREATE TABLE annotation_link (
-  annotation_link_id integer PRIMARY KEY AUTOINCREMENT,
-  cdna_acc varchar(250) default NULL,
-  gene_id varchar(200) default NULL,
-  model_id varchar(200) default NULL,
-  compare_id int(11) NOT NULL default '0'
+  annotation_link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cdna_acc TEXT DEFAULT NULL,
+  gene_id TEXT DEFAULT NULL,
+  model_id TEXT DEFAULT NULL,
+  compare_id INTEGER NOT NULL DEFAULT 0
 ) ;
 CREATE INDEX cdna_acc_idx ON annotation_link(cdna_acc);
 CREATE INDEX gene_id_idx ON annotation_link(gene_id);
@@ -125,23 +82,16 @@ CREATE INDEX mod_idx ON annotation_link(model_id);
 CREATE INDEX compare_idx ON annotation_link(compare_id);
 CREATE INDEX comp_id_acc_idx ON annotation_link(compare_id,cdna_acc);
 
---
--- Table structure for table 'annotation_store'
---
-
 CREATE TABLE annotation_store (
   annot_id INTEGER PRIMARY KEY AUTOINCREMENT,
-  gene_id varchar(200) NOT NULL default '',
-  model_id varchar(200) NOT NULL default '',
-  annotdb_asmbl_id varchar(200) NOT NULL default '',
-  lend integer NOT NULL default '0',
-  rend integer NOT NULL default '0',
-  orient char(1) NOT NULL default '',
-  gene_obj mediumblob NOT NULL,
-  annotation_version integer NOT NULL default '0',
-  CHECK(annotation_version >= 0),
-  CHECK(lend >= 0),
-  CHECK(rend >= 0)
+  gene_id TEXT NOT NULL DEFAULT '',
+  model_id TEXT NOT NULL DEFAULT '',
+  annotdb_asmbl_id TEXT NOT NULL DEFAULT '',
+  lend INTEGER NOT NULL DEFAULT 0 CHECK(lend >= 0),
+  rend INTEGER NOT NULL DEFAULT 0 CHECK(rend >= 0),
+  orient TEXT NOT NULL DEFAULT '' CHECK(orient IN ('', '+','-')),
+  gene_obj BLOB NOT NULL,
+  annotation_version INTEGER NOT NULL DEFAULT 0 CHECK(annotation_version >= 0)
 ) ;
 CREATE INDEX gene_index_coords ON annotation_store(annotdb_asmbl_id,lend,rend);
 CREATE INDEX geneid_idx ON annotation_store(gene_id);
@@ -149,85 +99,64 @@ CREATE INDEX modelid_idx ON annotation_store(model_id);
 CREATE INDEX annot_version_idx ON annotation_store(annotation_version);
 CREATE INDEX gene_idx ON annotation_store(annotation_version,gene_id);
 
---
--- Table structure for table 'annotation_updates'
---
-
 CREATE TABLE annotation_updates (
-  update_id integer PRIMARY KEY AUTOINCREMENT,
-  gene_id varchar(1000) default NULL,
-  model_id varchar(200) default NULL,
-  alt_splice_flag boolean NOT NULL default '0',
-  before_gene_obj mediumblob,
-  after_gene_obj mediumblob,
-  compare_id int(11) NOT NULL default '0',
-  is_valid boolean NOT NULL default '0',
-  have_before boolean NOT NULL default '0',
-  have_after boolean NOT NULL default '0',
-  is_novel_flag boolean default '0'
+  update_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  gene_id TEXT DEFAULT NULL,
+  model_id TEXT DEFAULT NULL,
+  alt_splice_flag BOOLEAN NOT NULL DEFAULT 0 CHECK(alt_splice_flag IN (0,1)),
+  before_gene_obj BLOB,
+  after_gene_obj BLOB,
+  compare_id INTEGER NOT NULL DEFAULT 0,
+  is_valid BOOLEAN NOT NULL DEFAULT 0 CHECK(is_valid IN (0,1)),
+  have_before BOOLEAN NOT NULL DEFAULT 0 CHECK(have_before IN (0,1)),
+  have_after BOOLEAN NOT NULL DEFAULT 0 CHECK(have_after IN (0,1)),
+  is_novel_flag BOOLEAN DEFAULT 0 CHECK(is_novel_flag IN (0,1))
 ) ;
 CREATE INDEX is_valid_idx ON annotation_updates(is_valid);
 CREATE INDEX alt_splice_idx ON annotation_updates(alt_splice_flag);
 CREATE INDEX lotsastuff_idx ON annotation_updates(gene_id,model_id,is_valid,alt_splice_flag);
 CREATE INDEX modelidx ON annotation_updates(model_id);
 
---
--- Table structure for table 'asmblPolyA'
---
-
 CREATE TABLE asmblPolyA (
-  asmbl_acc varchar(250) NOT NULL default '',
-  genomicCoord int(11) NOT NULL default '0',
-  asmblCoord int(11) NOT NULL default '0',
-  numSupportTranscripts int(11) NOT NULL default '0',
-  PRIMARY KEY  (asmbl_acc)
-) ;
-
---
--- Table structure for table 'asmbl_gene_objs'
---
+  asmbl_acc TEXT PRIMARY KEY,
+  genomicCoord INTEGER NOT NULL DEFAULT 0,
+  asmblCoord INTEGER NOT NULL DEFAULT 0,
+  numSupportTranscripts INTEGER NOT NULL DEFAULT 0
+) WITHOUT ROWID;
 
 CREATE TABLE asmbl_gene_objs (
-  id integer PRIMARY KEY AUTOINCREMENT,
-  cdna_acc varchar(50) NOT NULL default '',
-  allow_5prime_partial boolean NOT NULL default '0',
-  allow_3prime_partial boolean NOT NULL default '0',
-  gene_obj mediumblob NOT NULL,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cdna_acc TEXT NOT NULL DEFAULT '',
+  allow_5prime_partial BOOLEAN NOT NULL DEFAULT 0 CHECK(allow_5prime_partial IN (0,1)),
+  allow_3prime_partial BOOLEAN NOT NULL DEFAULT 0 CHECK(allow_3prime_partial IN (0,1)),
+  gene_obj BLOB NOT NULL,
   UNIQUE (cdna_acc,allow_5prime_partial,allow_3prime_partial)
 ) ;
 
---
--- Table structure for table 'asmbl_link'
---
-
 CREATE TABLE asmbl_link (
-  asmbl_acc varchar(100) NOT NULL default '',
-  cdna_acc varchar(100) NOT NULL default '',
-  PRIMARY KEY  (asmbl_acc,cdna_acc)
-) ;
+  asmbl_acc TEXT,
+  cdna_acc TEXT,
+  PRIMARY KEY (asmbl_acc,cdna_acc)
+) WITHOUT ROWID;
 CREATE INDEX cdna_idx ON asmbl_link(cdna_acc);
 
---
--- Table structure for table 'align_link'
---
-
 CREATE TABLE align_link (
-  align_id integer PRIMARY KEY AUTOINCREMENT,
-  cdna_info_id int(11) default  NULL,
-  align_acc varchar(100) default NULL,
-  cluster_id int(11) default NULL,
-  prog varchar(15) NOT NULL default '',
-  validate boolean default NULL,
-  spliced_orient char(1) default NULL,
-  num_segments smallint unsigned default NULL,
-  comment text,
-  alignment text,
-  avg_per_id double default NULL,
-  percent_aligned double default NULL,
-  score double default 0,
-  aligned_orient char(1) default NULL,
-  lend int(11) default 0,
-  rend int(11) default 0,
+  align_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cdna_info_id INTEGER DEFAULT NULL,
+  align_acc TEXT DEFAULT NULL,
+  cluster_id INTEGER DEFAULT NULL,
+  prog TEXT NOT NULL DEFAULT '',
+  validate BOOLEAN DEFAULT NULL CHECK(validate IN (0,1)),
+  spliced_orient TEXT DEFAULT NULL CHECK(spliced_orient IN ('', '+','-', '?')),
+  num_segments INTEGER DEFAULT NULL CHECK(num_segments >= 0),
+  comment TEXT,
+  alignment TEXT,
+  avg_per_id NUMERIC DEFAULT NULL,
+  percent_aligned REAL DEFAULT NULL,
+  score NUMERIC DEFAULT 0,
+  aligned_orient TEXT DEFAULT NULL CHECK(aligned_orient IN ('', '+','-')),
+  lend INTEGER DEFAULT 0,
+  rend INTEGER DEFAULT 0,
   UNIQUE (prog,align_acc)
 ) ;
 CREATE INDEX align_acc_idx ON align_link(align_acc);
@@ -236,142 +165,96 @@ CREATE INDEX cdna_info_id_idx ON align_link(cdna_info_id);
 CREATE INDEX cluster_id_idx ON align_link(cluster_id);
 CREATE INDEX progvalididx ON align_link(prog,validate);
 
---
--- Table structure for table 'cdna_sequence'
---
-
 CREATE TABLE cdna_sequence (
-  accession varchar(250) NOT NULL default '',
-  sequence MEDIUMTEXT,
-  PRIMARY KEY  (accession)
-) ;
-
---
--- Table structure for table 'cdna_info'
---
+  accession TEXT PRIMARY KEY,
+  sequence TEXT
+) WITHOUT ROWID;
 
 CREATE TABLE cdna_info (
-  cdna_acc varchar(100) default NULL,
-  id integer PRIMARY KEY AUTOINCREMENT,
-  is_assembly boolean NOT NULL default '0',
-  is_fli boolean NOT NULL default '0',
-  is_TDN boolean NOT NULL default '0',
-  length integer default NULL,
-  header text,
-  is_EST boolean default '0',
-  UNIQUE (cdna_acc),
-  CHECK(length >= 0)
+  cdna_acc TEXT UNIQUE DEFAULT NULL,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  is_assembly BOOLEAN NOT NULL DEFAULT 0 CHECK(is_assembly IN (0,1)),
+  is_fli BOOLEAN NOT NULL DEFAULT 0 CHECK(is_fli IN (0,1)),
+  is_TDN BOOLEAN NOT NULL DEFAULT 0 CHECK(is_TDN IN (0,1)),
+  length INTEGER DEFAULT NULL CHECK(length >= 0),
+  header TEXT,
+  is_EST BOOLEAN DEFAULT 0 CHECK(is_EST IN (0,1))
 ) ;
 CREATE INDEX is_fli_idx ON cdna_info(is_fli);
 CREATE INDEX is_assembly_idx ON cdna_info(is_assembly);
 
---
--- Table structure for table 'clusters'
---
-
 CREATE TABLE clusters (
-  cluster_id integer PRIMARY KEY AUTOINCREMENT,
-  lend integer default NULL,
-  rend integer default NULL,
-  annotdb_asmbl_id varchar(200) default NULL,
-  CHECK(lend >= 0),
-  CHECK(rend >= 0)
+  cluster_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  lend INTEGER DEFAULT NULL CHECK(lend >= 0),
+  rend INTEGER DEFAULT NULL CHECK(rend >= 0),
+  annotdb_asmbl_id TEXT DEFAULT NULL
 ) ;
 CREATE INDEX asmbl_id_idx ON clusters(annotdb_asmbl_id);
 
---
--- Table structure for table 'splice_variation'
---
-
 CREATE TABLE splice_variation (
-  sv_id integer PRIMARY KEY AUTOINCREMENT,
-  cdna_acc varchar(250) NOT NULL default '',
-  lend int(11) NOT NULL default '0',
-  rend int(11) NOT NULL default '0',
-  orient char(1) NOT NULL default '',
-  type varchar(50) NOT NULL default '',
-  num_subfeatures_included int(11) default '0',
-  subtype varchar(50) default NULL,
+  sv_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cdna_acc TEXT NOT NULL DEFAULT '',
+  lend INTEGER NOT NULL DEFAULT 0,
+  rend INTEGER NOT NULL DEFAULT 0,
+  orient TEXT NOT NULL DEFAULT '' CHECK(orient IN ('', '+','-')),
+  type TEXT NOT NULL DEFAULT '',
+  num_subfeatures_included INTEGER DEFAULT 0,
+  subtype TEXT DEFAULT NULL,
   UNIQUE (cdna_acc,lend,rend,orient,type)
 ) ;
 
---
--- Table structure for table 'splice_variation_support'
---
-
 CREATE TABLE splice_variation_support (
-  sv_id int(11) NOT NULL default '0',
-  cdna_acc varchar(250) NOT NULL default '',
-  transcripts_A text,
-  transcripts_B text,
-  num_transcripts_A int(11) default NULL,
-  num_transcripts_B int(11) default NULL,
+  sv_id INTEGER,
+  cdna_acc TEXT,
+  transcripts_A TEXT,
+  transcripts_B TEXT,
+  num_transcripts_A INTEGER DEFAULT NULL,
+  num_transcripts_B INTEGER DEFAULT NULL,
   PRIMARY KEY (cdna_acc,sv_id)
-) ;
-
---
--- Table structure for table 'status'
---
+) WITHOUT ROWID;
 
 CREATE TABLE status (
-  status_id integer PRIMARY KEY AUTOINCREMENT,
-  status_descr varchar(255) default NULL,
-  requires_update boolean default '0',
-  fails_incorporation boolean default '0',
-  rank float default '0'
+  status_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  status_descr TEXT DEFAULT NULL,
+  requires_update BOOLEAN DEFAULT 0 CHECK(requires_update IN (0,1)),
+  fails_incorporation BOOLEAN DEFAULT 0 CHECK(fails_incorporation IN (0,1)),
+  rank NUMERIC DEFAULT 0.0
 ) ;
 
---
--- Table structure for table 'status_link'
---
-
 CREATE TABLE status_link (
-  status_link_id integer PRIMARY KEY AUTOINCREMENT,
-  cdna_acc varchar(100) NOT NULL default '',
-  status_id int(11) NOT NULL default '0',
-  is_chromo boolean NOT NULL default '0',
-  comment text,
-  curated_exception boolean NOT NULL default '0',
-  curator_comment text,
-  compare_id int(11) NOT NULL default '0',
-  annot_update_id int(11) default NULL
+  status_link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cdna_acc TEXT NOT NULL DEFAULT '',
+  status_id INTEGER NOT NULL DEFAULT 0,
+  is_chromo BOOLEAN NOT NULL DEFAULT 0 CHECK(is_chromo IN (0,1)),
+  comment TEXT,
+  curated_exception BOOLEAN NOT NULL DEFAULT 0 CHECK(curated_exception IN (0,1)),
+  curator_comment TEXT,
+  compare_id INTEGER NOT NULL DEFAULT 0,
+  annot_update_id INTEGER DEFAULT NULL
 ) ;
 CREATE INDEX status_link_acc_idx ON status_link(cdna_acc);
 CREATE INDEX updateididx ON status_link(annot_update_id);
 CREATE INDEX status_link_compare_idx ON status_link(compare_id);
 
---
--- Table structure for table 'subcluster_link'
---
-
 CREATE TABLE subcluster_link (
-  subcluster_id int(11) NOT NULL default '0',
-  cdna_acc varchar(100) NOT NULL default '',
-  PRIMARY KEY  (subcluster_id,cdna_acc)
-) ;
+  subcluster_id INTEGER,
+  cdna_acc TEXT,
+  PRIMARY KEY (subcluster_id,cdna_acc)
+) WITHOUT ROWID;
 CREATE INDEX subcl_link_acc_idx ON subcluster_link(cdna_acc);
 
---
--- Table structure for table 'subclusters'
---
-
 CREATE TABLE subclusters (
-  subcluster_id integer PRIMARY KEY AUTOINCREMENT,
-  cluster_id int(11) NOT NULL default '0'
+  subcluster_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cluster_id INTEGER NOT NULL DEFAULT 0
 ) ;
 CREATE INDEX subcluster_cluster_id_idx ON subclusters(cluster_id);
 
---
--- Table structure for table 'transcriptPolyA'
---
-
 CREATE TABLE transcriptPolyA (
-  align_id int(11) NOT NULL,
-  genomicCoord int(11) NOT NULL default '0',
-  transcribedOrient char(1) NOT NULL default '',
-  trimType varchar(20) NOT NULL default '',
-  alignEndOffset int(11) NOT NULL default '0',
-  PRIMARY KEY  (align_id)
+  align_id INTEGER PRIMARY KEY,
+  genomicCoord INTEGER NOT NULL DEFAULT 0,
+  transcribedOrient TEXT NOT NULL DEFAULT '' CHECK(transcribedOrient IN ('', '+', '-')),
+  trimType TEXT NOT NULL DEFAULT '',
+  alignEndOffset INTEGER NOT NULL DEFAULT 0
 ) ;
 
 -- MySQL dump 8.22

--- a/schema/cdna_alignment_sqliteschema
+++ b/schema/cdna_alignment_sqliteschema
@@ -1,0 +1,460 @@
+CREATE TABLE URL_templates (
+  url_name varchar(20) NOT NULL default '',
+  url_template varchar(255) default NULL,
+  url_var_name varchar(20) NOT NULL default '',
+  PRIMARY KEY  (url_name)
+) ;
+
+--
+-- Table structure for table 'URL_var_names'
+--
+
+CREATE TABLE URL_var_names (
+  url_var_name varchar(20) NOT NULL default '',
+  PRIMARY KEY  (url_var_name)
+) ;
+
+--
+-- Table structure for table 'alignment'
+--
+
+CREATE TABLE alignment (
+  feat_id integer PRIMARY KEY AUTOINCREMENT,
+  align_id int(11) NOT NULL default '0',
+  lend int(11) NOT NULL default '0',
+  rend int(11) NOT NULL default '0',
+  mlend int(11) NOT NULL default '0',
+  mrend int(11) NOT NULL default '0',
+  orient char(1) default NULL,
+  per_id float default NULL
+) ;
+CREATE INDEX align_idx ON alignment(align_id);
+
+--
+-- Table structure for table 'alt_splice_FL_compare'
+--
+
+CREATE TABLE alt_splice_FL_compare (
+  row_id integer PRIMARY KEY AUTOINCREMENT,
+  template_cdna_acc varchar(50) default NULL,
+  classification varchar(250) NOT NULL default '',
+  lend int(11) NOT NULL default '0',
+  rend int(11) NOT NULL default '0',
+  orient char(1) NOT NULL default '',
+  type varchar(50) NOT NULL default ''
+) ;
+
+--
+-- Table structure for table 'alt_splice_FL_to_FL_compare'
+--
+
+CREATE TABLE alt_splice_FL_to_FL_compare (
+  row_id integer PRIMARY KEY AUTOINCREMENT,
+  template_acc varchar(50) NOT NULL default '',
+  other_acc varchar(50) NOT NULL default '',
+  diff_in_cds int(1) NOT NULL default '0',
+  frame_change int(1) NOT NULL default '0',
+  percent_prot_length float NOT NULL default '0',
+  num_variations int(11) NOT NULL default '0',
+  same_frame_exists int(1) NOT NULL default '0'
+) ;
+
+--
+-- Table structure for table 'alt_splice_link'
+--
+
+CREATE TABLE alt_splice_link (
+  sv_id_A int(11) NOT NULL default '0',
+  sv_id_B int(11) NOT NULL default '0',
+  UNIQUE (sv_id_A,sv_id_B)
+) ;
+CREATE INDEX sv_idx_B ON alt_splice_link(sv_id_B);
+
+--
+-- Table structure for table 'alt_splice_token_assignment'
+--
+
+CREATE TABLE alt_splice_token_assignment (
+  cdna_acc varchar(250) NOT NULL default '',
+  token_id int(11) NOT NULL default '0'
+) ;
+
+--
+-- Table structure for table 'alt_splice_tokens'
+--
+
+CREATE TABLE alt_splice_tokens (
+  token_id integer PRIMARY KEY AUTOINCREMENT,
+  alt_splice_token varchar(250) NOT NULL default ''
+) ;
+
+--
+-- Table structure for table 'annotation_admin'
+--
+
+CREATE TABLE annotation_admin (
+  version_id integer PRIMARY KEY AUTOINCREMENT,
+  date datetime NOT NULL
+) ;
+
+--
+-- Table structure for table 'annotation_compare'
+--
+
+CREATE TABLE annotation_compare (
+  compare_id integer PRIMARY KEY AUTOINCREMENT,
+  date datetime NOT NULL,
+  annotation_version integer NOT NULL default '0',
+  CHECK(annotation_version >= 0)
+) ;
+
+--
+-- Table structure for table 'annotation_link'
+--
+
+CREATE TABLE annotation_link (
+  annotation_link_id integer PRIMARY KEY AUTOINCREMENT,
+  cdna_acc varchar(250) default NULL,
+  gene_id varchar(200) default NULL,
+  model_id varchar(200) default NULL,
+  compare_id int(11) NOT NULL default '0'
+) ;
+CREATE INDEX cdna_acc_idx ON annotation_link(cdna_acc);
+CREATE INDEX gene_id_idx ON annotation_link(gene_id);
+CREATE INDEX mod_idx ON annotation_link(model_id);
+CREATE INDEX compare_idx ON annotation_link(compare_id);
+CREATE INDEX comp_id_acc_idx ON annotation_link(compare_id,cdna_acc);
+
+--
+-- Table structure for table 'annotation_store'
+--
+
+CREATE TABLE annotation_store (
+  annot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  gene_id varchar(200) NOT NULL default '',
+  model_id varchar(200) NOT NULL default '',
+  annotdb_asmbl_id varchar(200) NOT NULL default '',
+  lend integer NOT NULL default '0',
+  rend integer NOT NULL default '0',
+  orient char(1) NOT NULL default '',
+  gene_obj mediumblob NOT NULL,
+  annotation_version integer NOT NULL default '0',
+  CHECK(annotation_version >= 0),
+  CHECK(lend >= 0),
+  CHECK(rend >= 0)
+) ;
+CREATE INDEX gene_index_coords ON annotation_store(annotdb_asmbl_id,lend,rend);
+CREATE INDEX geneid_idx ON annotation_store(gene_id);
+CREATE INDEX modelid_idx ON annotation_store(model_id);
+CREATE INDEX annot_version_idx ON annotation_store(annotation_version);
+CREATE INDEX gene_idx ON annotation_store(annotation_version,gene_id);
+
+--
+-- Table structure for table 'annotation_updates'
+--
+
+CREATE TABLE annotation_updates (
+  update_id integer PRIMARY KEY AUTOINCREMENT,
+  gene_id varchar(1000) default NULL,
+  model_id varchar(200) default NULL,
+  alt_splice_flag boolean NOT NULL default '0',
+  before_gene_obj mediumblob,
+  after_gene_obj mediumblob,
+  compare_id int(11) NOT NULL default '0',
+  is_valid boolean NOT NULL default '0',
+  have_before boolean NOT NULL default '0',
+  have_after boolean NOT NULL default '0',
+  is_novel_flag boolean default '0'
+) ;
+CREATE INDEX is_valid_idx ON annotation_updates(is_valid);
+CREATE INDEX alt_splice_idx ON annotation_updates(alt_splice_flag);
+CREATE INDEX lotsastuff_idx ON annotation_updates(gene_id,model_id,is_valid,alt_splice_flag);
+CREATE INDEX modelidx ON annotation_updates(model_id);
+
+--
+-- Table structure for table 'asmblPolyA'
+--
+
+CREATE TABLE asmblPolyA (
+  asmbl_acc varchar(250) NOT NULL default '',
+  genomicCoord int(11) NOT NULL default '0',
+  asmblCoord int(11) NOT NULL default '0',
+  numSupportTranscripts int(11) NOT NULL default '0',
+  PRIMARY KEY  (asmbl_acc)
+) ;
+
+--
+-- Table structure for table 'asmbl_gene_objs'
+--
+
+CREATE TABLE asmbl_gene_objs (
+  id integer PRIMARY KEY AUTOINCREMENT,
+  cdna_acc varchar(50) NOT NULL default '',
+  allow_5prime_partial boolean NOT NULL default '0',
+  allow_3prime_partial boolean NOT NULL default '0',
+  gene_obj mediumblob NOT NULL,
+  UNIQUE (cdna_acc,allow_5prime_partial,allow_3prime_partial)
+) ;
+
+--
+-- Table structure for table 'asmbl_link'
+--
+
+CREATE TABLE asmbl_link (
+  asmbl_acc varchar(100) NOT NULL default '',
+  cdna_acc varchar(100) NOT NULL default '',
+  PRIMARY KEY  (asmbl_acc,cdna_acc)
+) ;
+CREATE INDEX cdna_idx ON asmbl_link(cdna_acc);
+
+--
+-- Table structure for table 'align_link'
+--
+
+CREATE TABLE align_link (
+  align_id integer PRIMARY KEY AUTOINCREMENT,
+  cdna_info_id int(11) default  NULL,
+  align_acc varchar(100) default NULL,
+  cluster_id int(11) default NULL,
+  prog varchar(15) NOT NULL default '',
+  validate boolean default NULL,
+  spliced_orient char(1) default NULL,
+  num_segments smallint unsigned default NULL,
+  comment text,
+  alignment text,
+  avg_per_id double default NULL,
+  percent_aligned double default NULL,
+  score double default 0,
+  aligned_orient char(1) default NULL,
+  lend int(11) default 0,
+  rend int(11) default 0,
+  UNIQUE (prog,align_acc)
+) ;
+CREATE INDEX align_acc_idx ON align_link(align_acc);
+CREATE INDEX align_id_idx ON align_link(align_id);
+CREATE INDEX cdna_info_id_idx ON align_link(cdna_info_id);
+CREATE INDEX cluster_id_idx ON align_link(cluster_id);
+CREATE INDEX progvalididx ON align_link(prog,validate);
+
+--
+-- Table structure for table 'cdna_sequence'
+--
+
+CREATE TABLE cdna_sequence (
+  accession varchar(250) NOT NULL default '',
+  sequence MEDIUMTEXT,
+  PRIMARY KEY  (accession)
+) ;
+
+--
+-- Table structure for table 'cdna_info'
+--
+
+CREATE TABLE cdna_info (
+  cdna_acc varchar(100) default NULL,
+  id integer PRIMARY KEY AUTOINCREMENT,
+  is_assembly boolean NOT NULL default '0',
+  is_fli boolean NOT NULL default '0',
+  is_TDN boolean NOT NULL default '0',
+  length integer default NULL,
+  header text,
+  is_EST boolean default '0',
+  UNIQUE (cdna_acc),
+  CHECK(length >= 0)
+) ;
+CREATE INDEX is_fli_idx ON cdna_info(is_fli);
+CREATE INDEX is_assembly_idx ON cdna_info(is_assembly);
+
+--
+-- Table structure for table 'clusters'
+--
+
+CREATE TABLE clusters (
+  cluster_id integer PRIMARY KEY AUTOINCREMENT,
+  lend integer default NULL,
+  rend integer default NULL,
+  annotdb_asmbl_id varchar(200) default NULL,
+  CHECK(lend >= 0),
+  CHECK(rend >= 0)
+) ;
+CREATE INDEX asmbl_id_idx ON clusters(annotdb_asmbl_id);
+
+--
+-- Table structure for table 'splice_variation'
+--
+
+CREATE TABLE splice_variation (
+  sv_id integer PRIMARY KEY AUTOINCREMENT,
+  cdna_acc varchar(250) NOT NULL default '',
+  lend int(11) NOT NULL default '0',
+  rend int(11) NOT NULL default '0',
+  orient char(1) NOT NULL default '',
+  type varchar(50) NOT NULL default '',
+  num_subfeatures_included int(11) default '0',
+  subtype varchar(50) default NULL,
+  UNIQUE (cdna_acc,lend,rend,orient,type)
+) ;
+
+--
+-- Table structure for table 'splice_variation_support'
+--
+
+CREATE TABLE splice_variation_support (
+  sv_id int(11) NOT NULL default '0',
+  cdna_acc varchar(250) NOT NULL default '',
+  transcripts_A text,
+  transcripts_B text,
+  num_transcripts_A int(11) default NULL,
+  num_transcripts_B int(11) default NULL,
+  PRIMARY KEY (cdna_acc,sv_id)
+) ;
+
+--
+-- Table structure for table 'status'
+--
+
+CREATE TABLE status (
+  status_id integer PRIMARY KEY AUTOINCREMENT,
+  status_descr varchar(255) default NULL,
+  requires_update boolean default '0',
+  fails_incorporation boolean default '0',
+  rank float default '0'
+) ;
+
+--
+-- Table structure for table 'status_link'
+--
+
+CREATE TABLE status_link (
+  status_link_id integer PRIMARY KEY AUTOINCREMENT,
+  cdna_acc varchar(100) NOT NULL default '',
+  status_id int(11) NOT NULL default '0',
+  is_chromo boolean NOT NULL default '0',
+  comment text,
+  curated_exception boolean NOT NULL default '0',
+  curator_comment text,
+  compare_id int(11) NOT NULL default '0',
+  annot_update_id int(11) default NULL
+) ;
+CREATE INDEX status_link_acc_idx ON status_link(cdna_acc);
+CREATE INDEX updateididx ON status_link(annot_update_id);
+CREATE INDEX status_link_compare_idx ON status_link(compare_id);
+
+--
+-- Table structure for table 'subcluster_link'
+--
+
+CREATE TABLE subcluster_link (
+  subcluster_id int(11) NOT NULL default '0',
+  cdna_acc varchar(100) NOT NULL default '',
+  PRIMARY KEY  (subcluster_id,cdna_acc)
+) ;
+CREATE INDEX subcl_link_acc_idx ON subcluster_link(cdna_acc);
+
+--
+-- Table structure for table 'subclusters'
+--
+
+CREATE TABLE subclusters (
+  subcluster_id integer PRIMARY KEY AUTOINCREMENT,
+  cluster_id int(11) NOT NULL default '0'
+) ;
+CREATE INDEX subcluster_cluster_id_idx ON subclusters(cluster_id);
+
+--
+-- Table structure for table 'transcriptPolyA'
+--
+
+CREATE TABLE transcriptPolyA (
+  align_id int(11) NOT NULL,
+  genomicCoord int(11) NOT NULL default '0',
+  transcribedOrient char(1) NOT NULL default '',
+  trimType varchar(20) NOT NULL default '',
+  alignEndOffset int(11) NOT NULL default '0',
+  PRIMARY KEY  (align_id)
+) ;
+
+-- MySQL dump 8.22
+--
+-- Host: bhaas-lx    Database: Testing_pasa2_B
+
+-- Server version	3.23.57
+
+--
+-- Dumping data for table 'status'
+--
+
+
+INSERT INTO status VALUES (1,'fl-cdna assembly fails validation tests.',0,1,1);
+INSERT INTO status VALUES (2,'fl-cdna assembly encodes inconsistent isoform (deprecated)',0,1,2);
+INSERT INTO status VALUES (3,'gene-compatible fl-cdna assembly incorporated',0,0,3);
+INSERT INTO status VALUES (4,'gene-compatible fl-cdna assembly alters UTRs.',1,0,4);
+INSERT INTO status VALUES (5,'fl-cdna assembly matches multiple genes suggesting gene merging required. (deprecated)',0,1,5);
+INSERT INTO status VALUES (6,'gene-compatible fl-cdna assembly alters protein, passed validation.',1,0,6);
+INSERT INTO status VALUES (7,'gene-compatible fl-cdna assembly alters protein, fails validation.',0,1,7);
+INSERT INTO status VALUES (8,'incompatible fl-cdna assembly alignment updates gene structure.',1,0,8);
+INSERT INTO status VALUES (9,'incompatible fl-cdna assembly provides alternative splicing isoform, passes validation.',1,0,9);
+INSERT INTO status VALUES (10,'fl-cdna assembly provides a novel gene.',1,0,10);
+INSERT INTO status VALUES (11,'EST assembly matches multiple genes, suggesting gene merging required.  (deprecated)',0,1,11);
+INSERT INTO status VALUES (12,'EST assembly incorporated.',0,0,12);
+INSERT INTO status VALUES (13,'EST assembly extends UTRs.',1,0,13);
+INSERT INTO status VALUES (14,'EST assembly alters protein sequence, passes validation.',1,0,14);
+INSERT INTO status VALUES (15,'EST assembly alters protein sequence, fails validation.',0,1,15);
+INSERT INTO status VALUES (16,'EST assembly properly stitched into gene structure.',1,0,16);
+INSERT INTO status VALUES (17,'EST assembly stitched into Gene model requires alternative splicing isoform. (deprecated, see status_ids: 24,25)',1,0,17);
+INSERT INTO status VALUES (24,'FL-cDNA assembly stitched by EST assembly to provide alt splicing isoform.',1,0,10.5);
+INSERT INTO status VALUES (18,'EST assembly stitched into gene model fails validation.',0,1,18);
+INSERT INTO status VALUES (19,'EST assembly aligns to intergenic region.',0,1,19);
+INSERT INTO status VALUES (20,'EST assembly overlaps non-validating existing annotated gene. (deprecated)',0,1,20);
+INSERT INTO status VALUES (21,'fl-cdna assembly provides alternate splicing isoform, fails validation',0,1,10.2);
+INSERT INTO status VALUES (22,'fl-cdna assembly provides novel gene which overlaps existing annotations',0,1,10.3);
+INSERT INTO status VALUES (23,'incompatible fl-cdna assembly fails validation',0,1,10.4);
+INSERT INTO status VALUES (25,'EST assembly stitched into Gene model requires alternative splicing isoform.',1,0,21);
+INSERT INTO status VALUES (26,'FL-cDNA spans single gene and allowed to STOMP it.',1,0,10.6);
+INSERT INTO status VALUES (27,'EST-assembly stitched into a FL-alignment providing new alt splice isoform.',1,0,21);
+INSERT INTO status VALUES (28,'EST-assembly stitched into a FL-alignment but fails validation tests.',0,1,22);
+INSERT INTO status VALUES (29,'FL-cDNA found capable of merging multiple genes',1,0,10.7);
+INSERT INTO status VALUES (30,'FL-cDNA overlaps multiple genes, but found incapable of merging them.',0,1,10.8);
+INSERT INTO status VALUES (31,'EST-stitched assembly STOMPS model lacking transcript support.',1,0,23);
+INSERT INTO status VALUES (32,'EST-stitched gene w/preexisting transcript support STOMPS a new alt splicing variation.',1,0,24);
+INSERT INTO status VALUES (33,'FL-assembly STOMPS new splice isoform',1,0,10.84);
+INSERT INTO status VALUES (34,'single-exon EST-assembly  fails gene compatibility test',0,1,25);
+INSERT INTO status VALUES (35,'EST-assembly  overlaps multiple genes, but found incapable of merging them.',0,1,26);
+INSERT INTO status VALUES (36,'EST-assembly found capable of merging multiple genes.',1,0,25.5);
+INSERT INTO status VALUES (37,'Delayed incorporation of FL-assembly due to successful merging operation.',0,1,10.89);
+INSERT INTO status VALUES (38,'Delayed incorporation of EST-assembly due to successful merging operation.',0,1,27);
+INSERT INTO status VALUES (39,'Delayed incorporation of FL-assembly due to successful splitting operation',0,1,10.92);
+INSERT INTO status VALUES (40,'FL-cDNAs split single gene into multiple genes',1,0,10.94);
+INSERT INTO status VALUES (41,'FL-cDNAs suggest split single gene into multiple genes, failed automation',0,1,10.95);
+INSERT INTO status VALUES (42,'FL-cDNA aligns as antisense to existing annotated gene',0,1,10.96);
+INSERT INTO status VALUES (43,'EST assembly aligns as antisense to existing annotated gene',0,1,25.6);
+INSERT INTO status VALUES (44,'FL-cDNA provides alt splicing isoform of a novel gene',1,0,10.97);
+INSERT INTO status VALUES (45,'fl-cdna assembly provides isoform for novel gene which overlaps existing annotations',0,1,10.35);
+
+-- MySQL dump 8.22
+--
+-- Host: bhaas-lx    Database: Testing_pasa2_B
+
+-- Server version	3.23.57
+
+
+INSERT INTO URL_templates VALUES ('manatee','http://manatee.tigr.org/tigr-scripts/euk_manatee/shared/ORF_infopage.cgi?db=__ANNOT_DB_NAME__;orf=__URLVAR__','model_id');
+INSERT INTO URL_templates VALUES ('GenomeViewer','http://intranet.tigr.org/tigr-scripts/AnnotationStation/AssemblyNavigator/euk_assembly_navigator.cgi?db=__ANNOT_DB_NAME__&LEND=__END5__&REND=__END3__&asmbl_id=__URLVAR__&submit=1','contig_id');
+
+-- MySQL dump 8.22
+--
+-- Host: bhaas-lx    Database: Testing_pasa2_B
+
+-- Server version	3.23.57
+
+--
+-- Dumping data for table 'URL_var_names'
+--
+
+
+INSERT INTO URL_var_names VALUES ('cdna_acc');
+INSERT INTO URL_var_names VALUES ('contig_id');
+INSERT INTO URL_var_names VALUES ('gene_id');
+INSERT INTO URL_var_names VALUES ('model_id');
+INSERT INTO URL_var_names VALUES ('pasa_acc');
+

--- a/scripts/Annotation_store_preloader.dbi
+++ b/scripts/Annotation_store_preloader.dbi
@@ -48,7 +48,7 @@ my $mysql_rw_password = &Pasa_conf::getParam("MYSQL_RW_PASSWORD");
 
 my $dbproc = &Mysql_connect::connect_to_db($mysql_server,$MYSQLdb,$mysql_rw_user,$mysql_rw_password);
 
-my $query = "insert annotation_admin (date) values (now())";
+my $query = "insert into annotation_admin (date) values (CURRENT_TIMESTAMP)";
 &Mysql_connect::RunMod($dbproc, $query);
 
 $query = "select LAST_INSERT_ID()";

--- a/scripts/Annotation_store_preloader.dbi
+++ b/scripts/Annotation_store_preloader.dbi
@@ -51,7 +51,7 @@ my $dbproc = &Mysql_connect::connect_to_db($mysql_server,$MYSQLdb,$mysql_rw_user
 my $query = "insert into annotation_admin (date) values (CURRENT_TIMESTAMP)";
 &Mysql_connect::RunMod($dbproc, $query);
 
-$query = "select LAST_INSERT_ID()";
+my $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
 my $annot_version = &Mysql_connect::very_first_result_sql($dbproc, $query);
 
 print "\n\nNow ready to load annotation version: $annot_version\n\n";

--- a/scripts/Launch_PASA_pipeline.pl
+++ b/scripts/Launch_PASA_pipeline.pl
@@ -254,8 +254,16 @@ if ($CREATE_MYSQL_DB) {
     
     if (&Pasa_conf::getParam("USE_PASA_DB_SETUP_HOOK") =~ /true/i) {
         &execute_custom_PASA_DB_setup_hook();
-    }
-    else {
+    } elsif ($mysql_server eq 'SQLite') {
+        &process_cmd(
+                     {
+                         prog => "sqlite3",
+                         params => $mysql_db,
+                         input => "$ENV{PASAHOME}/schema/cdna_alignment_sqliteschema",
+                         output => undef
+                         }
+                     );
+    } else {
         ## going the old fashioned way
 	my $params = "-c $opt_c -S $ENV{PASAHOME}/schema/cdna_alignment_mysqlschema";
 	$params .= ' -r' if $opt_r;

--- a/scripts/Load_Current_Gene_Annotations.dbi
+++ b/scripts/Load_Current_Gene_Annotations.dbi
@@ -126,7 +126,7 @@ while (my $seqobj = $fasta_reader->next() ) {
             
             my $blob = nfreeze($gene);
             
-            my $query = "insert annotation_store (gene_id, model_id, annotdb_asmbl_id, lend, rend, orient, annotation_version, gene_obj) values (?,?,?,?,?,?,?,?)";
+            my $query = "insert into annotation_store (gene_id, model_id, annotdb_asmbl_id, lend, rend, orient, annotation_version, gene_obj) values (?,?,?,?,?,?,?,?)";
             &Mysql_connect::RunMod($dbproc, $query, $gene_id, $model_id, $asmbl_id, $lend, $rend, $orient, $annot_version, $blob);
         }
     }

--- a/scripts/PASA_transcripts_and_assemblies_to_GFF3.dbi
+++ b/scripts/PASA_transcripts_and_assemblies_to_GFF3.dbi
@@ -98,7 +98,7 @@ my $query = "select al.align_id from align_link al, cdna_info ci "
 if ($prog_name) {
 
 	unless ($prog_name eq "ALL") {
-		$query .= " and al.prog = \"$prog_name\" " ;
+		$query .= " and al.prog = '$prog_name' " ;
 	}
 }	
 

--- a/scripts/alignment_assembly_to_gene_models.dbi
+++ b/scripts/alignment_assembly_to_gene_models.dbi
@@ -74,7 +74,7 @@ foreach my $result (@results) {
 }
 
 my $insert_query = qq {
-    insert asmbl_gene_objs (cdna_acc, allow_5prime_partial, allow_3prime_partial, gene_obj)
+    insert into asmbl_gene_objs (cdna_acc, allow_5prime_partial, allow_3prime_partial, gene_obj)
         values (?,?,?,?) 
     };
 

--- a/scripts/assembly_db_loader.dbi
+++ b/scripts/assembly_db_loader.dbi
@@ -107,7 +107,7 @@ foreach my $persobjfile (@assembly_files) {
 
     my $all_asmbls_aref = retrieve ($persobjfile);
     
-    my $query = "select max(align_id) from align_link where align_acc like \"asmbl%\"";
+    my $query = "select max(align_id) from align_link where align_acc like 'asmbl%'";
     my $result_ref = &first_result_sql($dbproc, $query);
     my $max_align_id = $result_ref->[0];
     my $asmbl = 0;
@@ -149,13 +149,13 @@ foreach my $persobjfile (@assembly_files) {
         
         ## insert asmbl_link
         foreach my $cdna (@cdnas) {
-            my $query = "insert asmbl_link (asmbl_acc, cdna_acc) values (?,?)";
+            my $query = "insert into asmbl_link (asmbl_acc, cdna_acc) values (?,?)";
             &RunMod($dbproc, $query, $asmbl_identifier, $cdna);
         }
         
         
         ## insert row in cluster_link table
-        my $query = "insert cdna_info (cdna_acc, is_assembly) values (?,?)";
+        my $query = "insert into cdna_info (cdna_acc, is_assembly) values (?,?)";
         &RunMod($dbproc, $query, $asmbl_identifier, 1);
         
         my $cdna_id = &get_last_insert_id($dbproc);
@@ -166,7 +166,7 @@ foreach my $persobjfile (@assembly_files) {
         my ($lend, $rend) = $assembly->get_coords();
         
         ## insert row in cdna_link
-        my $query = "insert align_link (align_acc, cdna_info_id, cluster_id, prog, validate, aligned_orient, spliced_orient, num_segments, lend, rend) values (?,?,?,?,?,?,?,?,?,?)";
+        my $query = "insert into align_link (align_acc, cdna_info_id, cluster_id, prog, validate, aligned_orient, spliced_orient, num_segments, lend, rend) values (?,?,?,?,?,?,?,?,?,?)";
         &RunMod($dbproc, $query, $asmbl_identifier, $cdna_id, $cluster_id, "assembler", 1, $aligned_orient, $spliced_orient, $num_segments, $lend, $rend);
         
         my $align_id = &get_last_insert_id($dbproc);
@@ -174,7 +174,7 @@ foreach my $persobjfile (@assembly_files) {
         foreach my $segment (@segments) {
             my ($lend, $rend) = sort {$a<=>$b} $segment->get_coords();
             my ($mlend, $mrend) = sort {$a<=>$b} $segment->get_mcoords();
-            my $query = "insert alignment (align_id, lend, rend, mlend, mrend, orient) values (?,?,?,?,?,?)";
+            my $query = "insert into alignment (align_id, lend, rend, mlend, mrend, orient) values (?,?,?,?,?,?)";
             &RunMod($dbproc, $query, $align_id, $lend, $rend, $mlend, $mrend, $aligned_orient);
             
         }

--- a/scripts/assign_clusters_by_gene_intergene_overlap.dbi
+++ b/scripts/assign_clusters_by_gene_intergene_overlap.dbi
@@ -255,7 +255,7 @@ sub insert_cluster {
 	if ($DEBUG) {
 		$cluster_id = "DEBUG_cluster_id";
 	} else {
-		my $query = "insert clusters (annotdb_asmbl_id) values (\"$asmbl_id\")";
+		my $query = "insert into clusters (annotdb_asmbl_id) values ('$asmbl_id')";
 		&RunMod($dbproc, $query);
 		$query = "select LAST_INSERT_ID()";
 		$cluster_id = &very_first_result_sql($dbproc, $query);

--- a/scripts/assign_clusters_by_gene_intergene_overlap.dbi
+++ b/scripts/assign_clusters_by_gene_intergene_overlap.dbi
@@ -257,7 +257,7 @@ sub insert_cluster {
 	} else {
 		my $query = "insert into clusters (annotdb_asmbl_id) values ('$asmbl_id')";
 		&RunMod($dbproc, $query);
-		$query = "select LAST_INSERT_ID()";
+        $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
 		$cluster_id = &very_first_result_sql($dbproc, $query);
 	}
 	

--- a/scripts/assign_clusters_by_stringent_alignment_overlap.dbi
+++ b/scripts/assign_clusters_by_stringent_alignment_overlap.dbi
@@ -249,7 +249,7 @@ sub insert_cluster {
 	} else {
 		my $query = "insert into clusters (annotdb_asmbl_id) values ('$asmbl_id')";
 		&RunMod($dbproc, $query);
-		$query = "select LAST_INSERT_ID()";
+		$query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
 		$cluster_id = &very_first_result_sql($dbproc, $query);
 	}
 	

--- a/scripts/assign_clusters_by_stringent_alignment_overlap.dbi
+++ b/scripts/assign_clusters_by_stringent_alignment_overlap.dbi
@@ -247,7 +247,7 @@ sub insert_cluster {
 	if ($DEBUG) {
 		$cluster_id = "DEBUG_cluster_id";
 	} else {
-		my $query = "insert clusters (annotdb_asmbl_id) values (\"$asmbl_id\")";
+		my $query = "insert into clusters (annotdb_asmbl_id) values ('$asmbl_id')";
 		&RunMod($dbproc, $query);
 		$query = "select LAST_INSERT_ID()";
 		$cluster_id = &very_first_result_sql($dbproc, $query);

--- a/scripts/build_comprehensive_transcriptome.dbi
+++ b/scripts/build_comprehensive_transcriptome.dbi
@@ -85,8 +85,10 @@ my $password = &Pasa_conf::getParam("MYSQL_RW_PASSWORD");
 
 my ($dbproc) = &connect_to_db($mysql_server,$mysql_db,$user,$password);
 
-my $query = "use $mysql_db";
-&RunMod($dbproc, $query);
+if ($dbproc->{__server} ne 'SQLite') {
+    my $query = "use $mysql_db";
+    &RunMod($dbproc, $query);
+}
 
 main: {
     

--- a/scripts/build_comprehensive_transcriptome.dbi
+++ b/scripts/build_comprehensive_transcriptome.dbi
@@ -392,7 +392,7 @@ sub maps_to_PASA_asm {
             
             ## get subcluster
             my $acc = $pasa_obj->get_acc();
-            my $query = "select subcluster_id from subcluster_link where cdna_acc = \"$acc\"";
+            my $query = "select subcluster_id from subcluster_link where cdna_acc = '$acc'";
             my $subcluster_id = &Mysql_connect::very_first_result_sql($dbproc, $query);
             print STDERR "\tSUBCLUSTER = $subcluster_id\n" if $DEBUG;
             return($subcluster_id);
@@ -417,7 +417,7 @@ sub get_overlapping_pasa_alignments {
     my $query = "select al.align_id "
         . " from align_link al, clusters c, cdna_info ci "
         . " where al.cluster_id = c.cluster_id "
-        . " and c.annotdb_asmbl_id = \"$scaffold\" "
+        . " and c.annotdb_asmbl_id = '$scaffold' "
         . " and al.cdna_info_id = ci.id "
         . " and ci.is_assembly = 1 "
         . " and al.validate = 1 "

--- a/scripts/build_comprehensive_transcriptome.tabix.dbi
+++ b/scripts/build_comprehensive_transcriptome.tabix.dbi
@@ -97,7 +97,7 @@ main: {
         my $query = "select c.annotdb_asmbl_id, al.lend, al.rend, al.align_acc, al.align_id, al.spliced_orient" 
             . " from align_link al, clusters c, cdna_info ci "
             . " where al.cluster_id = c.cluster_id "
-            #. " and c.annotdb_asmbl_id = \"$scaffold\" "
+            #. " and c.annotdb_asmbl_id = '$scaffold' "
             . " and al.cdna_info_id = ci.id "
             . " and ci.is_assembly = 1 "
             . " and al.validate = 1 "
@@ -419,7 +419,7 @@ sub maps_to_PASA_asm {
             
             ## get subcluster
             my $acc = $pasa_obj->get_acc();
-            my $query = "select subcluster_id from subcluster_link where cdna_acc = \"$acc\"";
+            my $query = "select subcluster_id from subcluster_link where cdna_acc = '$acc'";
             my $subcluster_id = &Mysql_connect::very_first_result_sql($dbproc, $query);
             print STDERR "\tSUBCLUSTER = $subcluster_id\n" if $DEBUG;
             return($subcluster_id);
@@ -444,7 +444,7 @@ sub get_overlapping_pasa_alignments {
     #my $query = "select al.align_id "
 	#    . " from align_link al, clusters c, cdna_info ci "
     #    . " where al.cluster_id = c.cluster_id "
-    #    . " and c.annotdb_asmbl_id = \"$scaffold\" "
+    #    . " and c.annotdb_asmbl_id = '$scaffold' "
     #    . " and al.cdna_info_id = ci.id "
     #    . " and ci.is_assembly = 1 "
     #    . " and al.validate = 1 "

--- a/scripts/cDNA_annotation_comparer.dbi
+++ b/scripts/cDNA_annotation_comparer.dbi
@@ -238,7 +238,7 @@ unless ($annot_version) {
 }
 
 ## get new compare_id
-$query = "insert annotation_compare (date, annotation_version) values (now(), $annot_version)";
+$query = "insert into annotation_compare (date, annotation_version) values (CURRENT_TIMESTAMP, $annot_version)";
 &Mysql_connect::RunMod($dbproc, $query);
 
 $query = "select LAST_INSERT_ID()";
@@ -1112,7 +1112,7 @@ sub summarize_asmbl_status {
             $values .= ",?";
             push (@params, $comment);
         }
-        my $query = "insert status_link ($fields) values ($values)";
+        my $query = "insert into status_link ($fields) values ($values)";
         &Mysql_connect::RunMod($dbproc, $query, @params);
         
         
@@ -1128,7 +1128,7 @@ sub summarize_asmbl_status {
         if ($#TUs > 0) { #multiple genes matched:
             foreach my $tu (@TUs) {
                 my $model = $Gene_to_model_list{$tu}->[0];
-                my $query = "insert annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
+                my $query = "insert into annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
                 &Mysql_connect::RunMod($dbproc, $query, $acc, $tu, $model, $compare_id);
             }
         } else { #only one gene, load gene and model:
@@ -1138,7 +1138,7 @@ sub summarize_asmbl_status {
                 $matching_gene_model_feat_name = $Gene_to_model_list{$overlapping_gene_text}->[0];
             }
             
-            my $query = "insert annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
+            my $query = "insert into annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
             &Mysql_connect::RunMod($dbproc, $query, $acc, $overlapping_gene_text, $matching_gene_model_feat_name, $compare_id);
         }
         
@@ -1267,7 +1267,7 @@ sub get_update_id {
     
     ## Insert new entry
     print "Inserting new entry in annotation_updates; getting an update_id for it.\n";
-    my $query = "insert annotation_updates (gene_id, model_id, alt_splice_flag, before_gene_obj, after_gene_obj, compare_id, is_valid, have_before, have_after, is_novel_flag) values (?,?,?,?,?,?,?,?,?,?)";
+    my $query = "insert into annotation_updates (gene_id, model_id, alt_splice_flag, before_gene_obj, after_gene_obj, compare_id, is_valid, have_before, have_after, is_novel_flag) values (?,?,?,?,?,?,?,?,?,?)";
     print "BLOB Length: after_gene_obj: " . length ($after_gene_obj);
     &Mysql_connect::RunMod($dbproc, $query, $gene_id, $model_id, $alt_splice_flag, undef, $after_gene_obj, $compare_id, $is_valid_flag, 0, 1, $is_novel_flag);
     
@@ -3345,7 +3345,7 @@ sub classify_antisense_transcripts {
     
     my $query = "select sl.cdna_acc "
         . " from status_link sl, align_link al, clusters c "
-        . " where c.annotdb_asmbl_id = \"$contig_id\" "
+        . " where c.annotdb_asmbl_id = '$contig_id' "
         . " and c.cluster_id = al.cluster_id "
         . " and al.align_acc = sl.cdna_acc "
         . " and sl.compare_id = $compare_id "
@@ -3426,7 +3426,7 @@ sub set_status_to_antisense {
     ## Insert new annotation link entries:
     foreach my $gene_id (@$overlapping_genes_aref) {
         my $model_id = $Gene_to_model_list{$gene_id}->[0];
-        my $query = "insert annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
+        my $query = "insert into annotation_link (cdna_acc, gene_id, model_id, compare_id) values (?,?,?,?)";
         &RunMod($dbproc, $query, $cdna_acc, $gene_id, $model_id, $compare_id);
     }
     

--- a/scripts/cDNA_annotation_comparer.dbi
+++ b/scripts/cDNA_annotation_comparer.dbi
@@ -241,7 +241,7 @@ unless ($annot_version) {
 $query = "insert into annotation_compare (date, annotation_version) values (CURRENT_TIMESTAMP, $annot_version)";
 &Mysql_connect::RunMod($dbproc, $query);
 
-$query = "select LAST_INSERT_ID()";
+$query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
 my $result = &Mysql_connect::first_result_sql($dbproc, $query);
 my $compare_id = $result->[0];
 
@@ -1271,7 +1271,7 @@ sub get_update_id {
     print "BLOB Length: after_gene_obj: " . length ($after_gene_obj);
     &Mysql_connect::RunMod($dbproc, $query, $gene_id, $model_id, $alt_splice_flag, undef, $after_gene_obj, $compare_id, $is_valid_flag, 0, 1, $is_novel_flag);
     
-    $query = "select LAST_INSERT_ID()";
+    $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
     my $result = &Mysql_connect::first_result_sql($dbproc, $query);
     $update_id = $result->[0];
     print ", UPDATE_ID: $update_id\n";

--- a/scripts/cDNA_annotation_updater.dbi
+++ b/scripts/cDNA_annotation_updater.dbi
@@ -298,8 +298,8 @@ if ($TARGETED_UPDATES{novel}) {
                 
                 ## this part is non-critical, and write access back to the mysql db may not be enabled.
                 eval {
-                	my $query = "update annotation_updates set gene_id = \"$new_gene_id\" "
-                    	. "where gene_id = \"$temp_gene_id\" and compare_id = $compare_id ";
+                	my $query = "update annotation_updates set gene_id = '$new_gene_id' "
+                    	. "where gene_id = '$temp_gene_id' and compare_id = $compare_id ";
                 	&Mysql_connect::RunMod($dbproc, $query);
                 };
                 if ($@) {

--- a/scripts/classify_alt_splice_as_UTR_or_protein.dbi
+++ b/scripts/classify_alt_splice_as_UTR_or_protein.dbi
@@ -704,7 +704,7 @@ sub insert_alt_splice_FL_to_FL_compare {
 ####
 sub clear_tables {
     foreach my $table ("alt_splice_FL_compare", "alt_splice_FL_to_FL_compare") {
-        my $query = "TRUNCATE TABLE $table";
+        my $query = ($dbproc->{__server} eq 'SQLite') ? "DELETE FROM $table" : "TRUNCATE TABLE $table";
         &RunMod($dbproc, $query);
     }
 }

--- a/scripts/classify_alt_splice_as_UTR_or_protein.dbi
+++ b/scripts/classify_alt_splice_as_UTR_or_protein.dbi
@@ -680,7 +680,7 @@ sub nucs_in_common {
 sub insert_alt_splice_FL_compare {
     my ($template_acc, $classification, $lend, $rend, $orient, $type) = @_;
     
-    my $query = qq { insert alt_splice_FL_compare (template_cdna_acc, classification, lend, rend, orient, type) 
+    my $query = qq { insert into alt_splice_FL_compare (template_cdna_acc, classification, lend, rend, orient, type) 
                          values (?,?,?,?,?,?)
                      };
     &RunMod($dbproc, $query, $template_acc, $classification, $lend, $rend, $orient, $type);
@@ -690,7 +690,7 @@ sub insert_alt_splice_FL_compare {
 sub insert_alt_splice_FL_to_FL_compare {
     my ($template_acc, $other_acc, $diff_in_cds, $same_frame_exists, $frame_change, $num_variations, $percent_prot_length) = @_;
 
-    my $query = qq {insert alt_splice_FL_to_FL_compare ( template_acc, other_acc, diff_in_cds, same_frame_exists, frame_change, num_variations, percent_prot_length)
+    my $query = qq {insert into alt_splice_FL_to_FL_compare ( template_acc, other_acc, diff_in_cds, same_frame_exists, frame_change, num_variations, percent_prot_length)
                         values (?,?,?,?,?,?,?)
                     };
 

--- a/scripts/classify_alt_splice_isoforms.dbi
+++ b/scripts/classify_alt_splice_isoforms.dbi
@@ -194,7 +194,7 @@ sub init_alt_splice_tables {
                      );
     
     foreach my $table (@tables) {
-        my $query = "TRUNCATE TABLE $table";
+        my $query = ($dbproc->{__server} eq 'SQLite') ? "DELETE FROM $table" : "TRUNCATE TABLE $table";
         &RunMod($dbproc, $query);
     }
     

--- a/scripts/classify_alt_splice_isoforms.dbi
+++ b/scripts/classify_alt_splice_isoforms.dbi
@@ -237,7 +237,7 @@ sub summarize_labels() {
             $token_id = $label_to_token_id{$label} = &get_splice_token($label);
         }
 
-        my $query = "insert alt_splice_token_assignment (cdna_acc, token_id) values (?,?)";
+        my $query = "insert into alt_splice_token_assignment (cdna_acc, token_id) values (?,?)";
         &RunMod($dbproc, $query, $cdna_acc, $token_id);
 
     }
@@ -254,7 +254,7 @@ sub summarize_labels() {
 sub get_splice_token {
     my $label = shift;
 
-    my $query = "insert alt_splice_tokens (alt_splice_token) values (?)";
+    my $query = "insert into alt_splice_tokens (alt_splice_token) values (?)";
     &RunMod($dbproc, $query, $label);
     
     my $token_id = &get_last_insert_id($dbproc);

--- a/scripts/classify_alt_splice_isoforms_per_subcluster.dbi
+++ b/scripts/classify_alt_splice_isoforms_per_subcluster.dbi
@@ -394,7 +394,7 @@ sub store_splice_variation {
     } 
 
     ## insert it:
-    $query = qq { insert splice_variation (cdna_acc, lend, rend, orient, type, num_subfeatures_included) values 
+    $query = qq { insert into splice_variation (cdna_acc, lend, rend, orient, type, num_subfeatures_included) values 
                       (?,?,?,?,?,?) };
     &RunMod($dbproc, $query, $cdna_acc, $lend, $rend, $orient, $type, $num_subfeatures_included);
     
@@ -413,7 +413,7 @@ sub add_splice_variation_support {
     print "Count: $count\n" if $SEE;
     
     unless ($count) {
-        my $query = "insert splice_variation_support (sv_id, cdna_acc) values (?,?)";
+        my $query = "insert into splice_variation_support (sv_id, cdna_acc) values (?,?)";
         &RunMod($dbproc, $query, $sv_id, $other_acc);
     }
 }
@@ -428,7 +428,7 @@ sub link_alt_splice {
     my $count = &very_first_result_sql($dbproc, $query, $sv_id_A, $sv_id_B);
     
     unless ($count) {
-        my $query = "insert alt_splice_link (sv_id_A, sv_id_B) values (?,?)";
+        my $query = "insert into alt_splice_link (sv_id_A, sv_id_B) values (?,?)";
         &RunMod($dbproc, $query, $sv_id_A, $sv_id_B);
     }
 }

--- a/scripts/compute_gene_coverage_by_incorporated_PASA_assemblies.dbi
+++ b/scripts/compute_gene_coverage_by_incorporated_PASA_assemblies.dbi
@@ -121,7 +121,7 @@ foreach my $model_id (keys %model_to_cdna_accs) {
 		my ($lend, $rend) = &Ath1_cdnas::get_alignment_span($dbproc, $cdna);
 		
 		## get the align_id:
-        my $query = "select align_id from cdna_link where cdna_acc = \"$cdna\" and validate = 1";
+        my $query = "select align_id from cdna_link where cdna_acc = '$cdna' and validate = 1";
         my $align_id = &Mysql_connect::very_first_result_sql($dbproc, $query);
         my $cdna_obj = &Ath1_cdnas::create_alignment_obj($dbproc, $align_id);
 		

--- a/scripts/dump_annot_store.dbi
+++ b/scripts/dump_annot_store.dbi
@@ -75,10 +75,10 @@ my $query = "select annot_id, gene_id, model_id, annotdb_asmbl_id, lend, rend, o
 if ($gene_id || $model_id || $gene_id) {
     $query .= " where ";
     if ($gene_id) {
-        $query .= " and gene_id = \"$gene_id\" ";
+        $query .= " and gene_id = '$gene_id' ";
     }
     if ($model_id) {
-        $query .= " and model_id = \"$model_id\" ";
+        $query .= " and model_id = '$model_id' ";
     }
     if ($annotation_version) {
         $query .= " and annotation_version = $annotation_version ";

--- a/scripts/ensure_single_valid_alignment_per_cdna_per_cluster.pl
+++ b/scripts/ensure_single_valid_alignment_per_cdna_per_cluster.pl
@@ -45,8 +45,10 @@ my $password = &Pasa_conf::getParam("MYSQL_RW_PASSWORD");
 
 my ($dbproc) = &connect_to_db($mysql_server,$mysql_db,$user,$password);
 
-my $query = "use $mysql_db";
-&RunMod($dbproc, $query);
+if ($dbproc->{__server} ne 'SQLite') {
+    my $query = "use $mysql_db";
+    &RunMod($dbproc, $query);
+}
 
 my $query = "select ci.cdna_acc, a.cluster_id, a.cdna_info_id, a.align_id, a.align_acc, a.prog, a.score "
     . " from cdna_info ci, align_link a "

--- a/scripts/find_alternate_internal_exons.dbi
+++ b/scripts/find_alternate_internal_exons.dbi
@@ -218,7 +218,7 @@ sub link_alt_splice {
         my ($entry_A, $entry_B) = @$pair_aref;
         
         eval {
-            my $query = "insert alt_splice_link (sv_id_A, sv_id_B) values (?,?)";
+            my $query = "insert into alt_splice_link (sv_id_A, sv_id_B) values (?,?)";
             &RunMod($dbproc, $query, $entry_A, $entry_B);
         };
 

--- a/scripts/import_custom_alignments.dbi
+++ b/scripts/import_custom_alignments.dbi
@@ -171,7 +171,7 @@ sub store_cluster_links {
 
         ## install row in clusters table
 
-        my $query = qq { insert clusters (annotdb_asmbl_id) values (?) };
+        my $query = qq { insert into clusters (annotdb_asmbl_id) values (?) };
         &RunMod($dbproc, $query, $asmbl_id);
         
         my $cluster_id = &Mysql_connect::get_last_insert_id($dbproc);

--- a/scripts/import_spliced_alignments.dbi
+++ b/scripts/import_spliced_alignments.dbi
@@ -220,7 +220,7 @@ sub store_cluster_links {
 
         ## install row in clusters table
 
-        my $query = qq { insert clusters (annotdb_asmbl_id) values (?) };
+        my $query = qq { insert into clusters (annotdb_asmbl_id) values (?) };
         &RunMod($dbproc, $query, $asmbl_id);
         
         my $cluster_id = &Mysql_connect::get_last_insert_id($dbproc);

--- a/scripts/invalidate_single_exon_ESTs.dbi
+++ b/scripts/invalidate_single_exon_ESTs.dbi
@@ -50,7 +50,7 @@ my @results = &do_sql_2D($dbproc, $query);
 
 
 # prepare a query for invalidation of transcripts
-my $invalidate_query = "update align_link set validate = 0, comment = \"invalidated (valid) single exon est alignment\" where validate =  1 and align_id = ?";
+my $invalidate_query = "update align_link set validate = 0, comment = 'invalidated (valid) single exon est alignment' where validate =  1 and align_id = ?";
 my $sth = $dbproc->{dbh}->prepare ($invalidate_query) or die $dbproc->{dbh}->errstr;
 
 foreach my $result (@results) {

--- a/scripts/polyA_site_transcript_mapper.dbi
+++ b/scripts/polyA_site_transcript_mapper.dbi
@@ -488,7 +488,7 @@ sub load_PolyA_info_in_DB {
     
     $trimType = ($trimType eq "lend") ? "lend_PolyT" : "rend_PolyA";
     
-    my $query = "insert transcriptPolyA (align_id, genomicCoord, transcribedOrient, trimType, alignEndOffset) values (?,?,?,?,?)";
+    my $query = "insert into transcriptPolyA (align_id, genomicCoord, transcribedOrient, trimType, alignEndOffset) values (?,?,?,?,?)";
     &RunMod($dbproc, $query, $align_id, $genomicCoord, $transcribedOrient, $trimType, $offset);
     
     ## update spliced orient for single exon alignments to transcribed orient

--- a/scripts/populate_alignments_via_btab.dbi
+++ b/scripts/populate_alignments_via_btab.dbi
@@ -101,7 +101,7 @@ sub store_cluster_links {
         my @accs = keys %{$asmbl_id_to_acc{$asmbl_id}};
         
         ## install row in clusters table                                                                                           
-        my $query = qq { insert clusters (annotdb_asmbl_id) values (?) };
+        my $query = qq { insert into clusters (annotdb_asmbl_id) values (?) };
         &RunMod($dbproc, $query, $asmbl_id);
         
         my $cluster_id = &Mysql_connect::get_last_insert_id($dbproc);
@@ -134,7 +134,7 @@ sub process_alignment() {
     }
     
 
-    my $query = "insert cdna_link (cdna_acc, prog, aligned_orient) values (?,?,?)";
+    my $query = "insert into cdna_link (cdna_acc, prog, aligned_orient) values (?,?,?)";
     &RunMod ($dbproc, $query, $acc, $prog, $orientation);
     
     my $query = "select LAST_INSERT_ID()";
@@ -154,7 +154,7 @@ sub process_alignment() {
             my $per_id = $coordset_href->{per_id};
             print "g5: $gend5\tg3: $gend3\tc5: $cdnaend5\tc3: $cdnaend3\n" if $SEE;
             ($gend5, $gend3) = sort {$a<=>$b} ($gend5, $gend3);
-            my $query = "insert alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
+            my $query = "insert into alignment (align_id, lend, rend, mlend, mrend, orient, per_id) values (?,?,?,?,?,?,?)";
             &RunMod($dbproc, $query, $align_id, $gend5, $gend3, $cdnaend5, $cdnaend3, $orientation, $per_id);
             
         }

--- a/scripts/populate_alignments_via_btab.dbi
+++ b/scripts/populate_alignments_via_btab.dbi
@@ -137,7 +137,7 @@ sub process_alignment() {
     my $query = "insert into cdna_link (cdna_acc, prog, aligned_orient) values (?,?,?)";
     &RunMod ($dbproc, $query, $acc, $prog, $orientation);
     
-    my $query = "select LAST_INSERT_ID()";
+    my $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
     my $result_aref = &first_result_sql ($dbproc, $query);
     my $align_id = $result_aref->[0];
     

--- a/scripts/populate_ath1_cdnas.dbi
+++ b/scripts/populate_ath1_cdnas.dbi
@@ -105,7 +105,7 @@ sub insert_cdna_info {
     
     ## Make an alignment entry:
     my $asmbl_id = $blat_accs{$cdnas[0]}; #get asmbl_id
-    my $query = "insert clusters (annotdb_asmbl_id) values (?)\n";
+    my $query = "insert into clusters (annotdb_asmbl_id) values (?)\n";
     &Mysql_connect::RunMod($dbproc, $query, $asmbl_id);
     
     my $cluster_id = &get_last_insert_id($dbproc);

--- a/scripts/populate_cdna_clusters.dbi
+++ b/scripts/populate_cdna_clusters.dbi
@@ -101,11 +101,11 @@ system "rm -rf clusters";
 ####
 sub insert_cdna_info {
     my (@cdnas) = @_;
-    print "inserting cdnas: @cdnas\n" if $SEE;
+    print "inserting into cdnas: @cdnas\n" if $SEE;
     
     ## Make an alignment entry:
     my $asmbl_id = $blat_accs{$cdnas[0]}; #get asmbl_id
-    my $query = "insert clusters (annotdb_asmbl_id) values (?)\n";
+    my $query = "insert into clusters (annotdb_asmbl_id) values (?)\n";
     &Mysql_connect::RunMod($dbproc, $query, $asmbl_id);
     
     my $cluster_id = &get_last_insert_id($dbproc);

--- a/scripts/populate_mysql_assembly_alignment_field.dbi
+++ b/scripts/populate_mysql_assembly_alignment_field.dbi
@@ -68,7 +68,7 @@ foreach my $result (@results) {
     my $alignment = $cdna_alignment->toToken();
     print "$cdna_acc\t$alignment\n\n" if $SEE;
 
-    my $query = "update align_link set alignment = \"$alignment\" where align_id = $align_id ";
+    my $query = "update align_link set alignment = '$alignment' where align_id = $align_id ";
     &Mysql_connect::RunMod($dbproc, $query);
 
     if ($process % 100 == 0){

--- a/scripts/populate_mysql_assembly_sequence_field.dbi
+++ b/scripts/populate_mysql_assembly_sequence_field.dbi
@@ -74,7 +74,7 @@ foreach my $result (@results) {
     my $assembly_seq = uc $cdna_alignment->extractSplicedSequence();
     
     unless ($opt_X) {
-        my $query = "insert cdna_sequence (accession, sequence) values (?,?)";
+        my $query = "insert into cdna_sequence (accession, sequence) values (?,?)";
         &RunMod($dbproc, $query, $cdna_acc, $assembly_seq);
     }
     

--- a/scripts/reassign_clusters_via_valid_align_coords.dbi
+++ b/scripts/reassign_clusters_via_valid_align_coords.dbi
@@ -125,7 +125,7 @@ foreach my $result (@results) {
             my ($cluster, $asmbl_id, $coords) = split(/\t/);
             my ($lend, $rend) = split(/-/, $coords);
             
-            my $query = "insert clusters (annotdb_asmbl_id, lend, rend) values (?, ?, ?)";
+            my $query = "insert into clusters (annotdb_asmbl_id, lend, rend) values (?, ?, ?)";
             &RunMod($dbproc, $query, $asmbl_id, $lend, $rend);
             $query = "select LAST_INSERT_ID()";
             $cluster_id = &very_first_result_sql($dbproc, $query);

--- a/scripts/reassign_clusters_via_valid_align_coords.dbi
+++ b/scripts/reassign_clusters_via_valid_align_coords.dbi
@@ -127,7 +127,7 @@ foreach my $result (@results) {
             
             my $query = "insert into clusters (annotdb_asmbl_id, lend, rend) values (?, ?, ?)";
             &RunMod($dbproc, $query, $asmbl_id, $lend, $rend);
-            $query = "select LAST_INSERT_ID()";
+            $query = ($dbproc->{__server} eq 'SQLite') ? 'select last_insert_rowid()' : "select LAST_INSERT_ID()";
             $cluster_id = &very_first_result_sql($dbproc, $query);
         }
         else {

--- a/scripts/reset_to_prior_to_assembly_build.dbi
+++ b/scripts/reset_to_prior_to_assembly_build.dbi
@@ -75,7 +75,7 @@ foreach my $table ( qw (alt_splice_FL_compare
 my $query = "delete from cluster_link where is_assembly = 1";
 &RunMod($dbproc, $query);
 
-$query = "delete from cdna_link where cdna_acc like \"asmbl_%\"";
+$query = "delete from cdna_link where cdna_acc like 'asmbl_%'";
 &RunMod($dbproc, $query);
 
 $query = "select max(align_id) from cdna_link";

--- a/scripts/subcluster_builder.dbi
+++ b/scripts/subcluster_builder.dbi
@@ -91,7 +91,7 @@ foreach my $result (@results) {
     ## Get all cluster info for that chromosome
     my $query = "select distinct c.cluster_id, c.lend, c.rend "
         . " from clusters c, align_link al, cdna_info ci "
-        . " where c.annotdb_asmbl_id = \"$asmbl_id\" and al.cluster_id = c.cluster_id and al.cdna_info_id = ci.id and ci.is_assembly = 1 ";
+        . " where c.annotdb_asmbl_id = '$asmbl_id' and al.cluster_id = c.cluster_id and al.cdna_info_id = ci.id and ci.is_assembly = 1 ";
     my @results = &Mysql_connect::do_sql_2D($dbproc, $query);
     
     my @clusters; #index to bin of clusters

--- a/scripts/subcluster_loader.dbi
+++ b/scripts/subcluster_loader.dbi
@@ -78,12 +78,12 @@ while (<STDIN>) {
     } elsif (/fli-containing:\s(\S+)/) {
         my $acc = $1;
         print "update $acc to fl status.\n" if $SEE;
-        my $query = "update cdna_info set is_fli = 1 where cdna_acc = \"$acc\"\n";
+        my $query = "update cdna_info set is_fli = 1 where cdna_acc = '$acc'\n";
         &RunMod($dbproc, $query);
     } elsif (/sub-cluster:\s(.*)$/) {
         my $acc_list = $1;
         my @accs = split (/\s+/, $acc_list);
-        my $query = "insert subclusters (cluster_id) values ($cluster)";
+        my $query = "insert into subclusters (cluster_id) values ($cluster)";
         &RunMod($dbproc, $query);
         my $query = "select max(subcluster_id) from subclusters where cluster_id = $cluster";
         my $result_aref = &first_result_sql($dbproc, $query);
@@ -95,7 +95,7 @@ while (<STDIN>) {
 
         foreach my $acc (@accs) {
             print "\t$acc\n" if $SEE;
-            my $query = "insert subcluster_link (subcluster_id, cdna_acc) values ($subcluster_id, \"$acc\")";
+            my $query = "insert into subcluster_link (subcluster_id, cdna_acc) values ($subcluster_id, '$acc')";
             &RunMod($dbproc, $query);
         }
         

--- a/scripts/update_fli_status.dbi
+++ b/scripts/update_fli_status.dbi
@@ -73,7 +73,7 @@ while (<$filehandle>) {
     my (@x) = split (/\s+/);
     my $acc = shift @x;
     $acc =~ s/>//;
-    my $query = "update cdna_info set is_fli = 1 where cdna_acc = \"$acc\"\n";
+    my $query = "update cdna_info set is_fli = 1 where cdna_acc = '$acc'\n";
     &RunMod($dbproc, $query);
     
     print STDERR "-updating $acc => full-length status.\n" if $SEE || $DEBUG;

--- a/scripts/upload_transcript_data.dbi
+++ b/scripts/upload_transcript_data.dbi
@@ -93,7 +93,7 @@ while (my $seqObj = $fasta_reader->next()) {
     my $fl_flag = $FL{$acc} || 0;
     my $TDN_flag = $TDN{$acc} || 0;
 
-    my $query = qq { insert cdna_info (cdna_acc, is_assembly, is_fli, is_TDN, length, header) values (?,?,?,?,?,?) };
+    my $query = qq { insert into cdna_info (cdna_acc, is_assembly, is_fli, is_TDN, length, header) values (?,?,?,?,?,?) };
     &RunMod($dbproc, $query, $acc, 0, $fl_flag, $TDN_flag, $seq_length, $header);
     
     if ($fl_flag) {

--- a/scripts/validate_alignments_in_db.dbi
+++ b/scripts/validate_alignments_in_db.dbi
@@ -283,7 +283,7 @@ sub validate_alignments_on_asmbl_id {
       . " and al.validate is null";
 	  
     if ($prog_type) {
-        $query .= " and al.prog = \"$prog_type\" ";
+        $query .= " and al.prog = '$prog_type' ";
     }
 	
     my @results = &Mysql_connect::do_sql_2D($dbproc, $query, $asmbl_id);


### PR DESCRIPTION
PASA is difficult to run on an HPC cluster due to the MySQL requirement. As an alternative to rearchitecting PASA to completely remove the dependency on a relational database, adding support for SQLite could involve much less development effort and provide enough capability/compatibility to run on most such systems (assuming, e.g., that the SQLite database isn't placed on a Lustre file system that has been mounted with _noflock_ to disable file locking).

To get the ball rolling, I've done a minimal SQLite port that at least seems to be enough for run_sample_data.pl  to complete without error. To use SQLite, in the pasa_conf/conf.txt file, set:
```
MYSQLSERVER=SQLite
```
Then the MYSQLDATABASE parameter is used as a pathname to an SQLite database.                                                                                                                                                                 A few caveats:
* The results of run_sample_data.pl haven't been compared with the results vs. when MySQL is used                      
* Web UI is completely untested
* The schema has been minimally translated from MySQL, with a few perhaps-unnecessary CHECK constraints in lieu of (unsupported) unsigned integers in random places.