### PR TITLE
simple fix - force hostname split to 2 fields 

### DIFF
--- a/scripts/pasa_asmbl_genes_to_GFF3.dbi
+++ b/scripts/pasa_asmbl_genes_to_GFF3.dbi
@@ -45,12 +45,12 @@ _EOH_
 if ($opt_h) {die $usage;}
 my $MYSQLstring = $opt_M or die "Must indicate MySQL parameters.\n\n$usage";
 
-my ($MYSQLdb, $MYSQLserver) = split (/:/, $MYSQLstring); 
+my ($MYSQLdb, $MYSQLserver) = split (/:/, $MYSQLstring,2); 
 my $passwordinfo = $opt_p or die "Must specify password info.\n\n\n$usage";
 my $DEBUG = $opt_d;
 
 our $SEE = $opt_v;
-my ($user, $password) = split (/:/, $passwordinfo);
+my ($user, $password) = split (/:/, $passwordinfo,2);
 my $type = $opt_t || "both";
 
 my ($allow_5prime_partial, $allow_3prime_partial) = (1,1);


### PR DESCRIPTION
Parsing MYSQLstring string (which I think is being passed in instead of parsing conf file)  - force it to be 2 fields from MYSQLstring - currently by passing in string instead of parsing conf file for bug #159 

This handles my use case where the host port is encoded in the server name : 
eg: DBNAME:HOSTNAME:PORT
myDB:host123:33021 
wasn't working as the trailing port was lost.