### PR TITLE
allow relative path for SQLite db

### DIFF
--- a/PerlLib/DB_connect.pm
+++ b/PerlLib/DB_connect.pm
@@ -32,7 +32,7 @@ my $CONNECTED_FLAG = 0; # set to 1 on first db connection. Mostly for logging in
 sub configure_db_driver {
     my ($db) = @_;
     
-    if ($db =~ /^\//) {
+    if ($db =~ /^\.*\//) {
         # have fully qualified path:
         $ENV{DBI_DRIVER} = 'SQLite';
         print STDERR "-connecting to SQLite db: $db\n" unless $CONNECTED_FLAG;


### PR DESCRIPTION
Hi there,

I had to modify DB_connect.pm file in order to allow relative path for SQLlite. I found it useful running PASApipeline in a nextflow workflow. (Since it uses a work dir cache system which badly integrates with absolute path)

I had no trouble or issue running PASApipeline steps I needed in my workflow.

Maybe this modification is not desirable, feel free to comment or discard it ;)
In such case, can you please explain to me why this modification could lead to some issues ?

br
Tom

