### PR TITLE
Fix bug for the calculation of read length

### DIFF
--- a/PerlLib/SAM_entry.pm
+++ b/PerlLib/SAM_entry.pm
@@ -230,6 +230,12 @@ sub get_alignment_coords {
         unless ($read_len) {
             confess "Error, no read length obtained from entry: " . $self->get_original_line();
         }
+	if($alignment =~ /^(\d+)H/){
+            $read_len += $1
+        }
+        if($alignment =~ /(\d+)H$/){
+            $read_len += $1
+        }
 
         my @revcomp_coords;
         foreach my $coordset (@query_coords) {


### PR DESCRIPTION
"H" in CIGAR string means hard clipping, which means clipped sequences NOT present in SEQ, which can only be present as the first and/or last operation (see https://samtools.github.io/hts-specs/SAMv1.pdf). Therefore, read length is equal to the length of SEQ ($self->{_fields}->[9]) plus the length of hard clipped sequences.