### PR TITLE
Fix tmp output file name of pblat

### DIFF
--- a/scripts/process_PBLAT_alignments.pl
+++ b/scripts/process_PBLAT_alignments.pl
@@ -87,8 +87,8 @@ if (! -d $checkpt_dir) {
 my $pipeliner = new Pipeliner("-checkpoint_dir" => $checkpt_dir, "-verbose" => 2);
 
 
-
-my $ooc_cmd = "$blat_path $genome_db $transcript_db -q=rna -dots=100 -maxIntron=$MAX_INTRON -threads=$CPU  -makeOoc=11.ooc /dev/null";
+my $ooc_cmd_tmp_out = "tmp-$$-" . int(rand(100000)) . "-out";
+my $ooc_cmd = "$blat_path $genome_db $transcript_db -q=rna -dots=100 -maxIntron=$MAX_INTRON -threads=$CPU  -makeOoc=11.ooc $ooc_cmd_tmp_out";
 my $ooc_chckpt = "11.ooc.ok";
 $pipeliner->add_commands(new Command($ooc_cmd, $ooc_chckpt));
 


### PR DESCRIPTION
In multithreading mode, `pblat` will automatically generate a set of temporary outfile files for each thread (see https://github.com/icebert/pblat/blob/98df9e0976c321903c66aa89a1a585b1ea9e8df5/blatSrc/blat.c#L975). The temporary output file name (`/dev/null`) here of `$ooc_cmd` will cause an error that users could not create the file `/dev/null.tmp.1`.