### PR TITLE
Pipeline re-execution skips failed minimap2

### DIFF
--- a/scripts/process_minimap2_alignments.pl
+++ b/scripts/process_minimap2_alignments.pl
@@ -4,8 +4,13 @@ use strict;
 use warnings;
 
 use FindBin;
+use lib ($FindBin::Bin);
+use Pasa_init;
+
 use File::Basename;
 use Cwd;
+
+use Pipeliner;
 
 use Carp;
 use Getopt::Long qw(:config no_ignore_case bundling pass_through);
@@ -65,18 +70,16 @@ unless ($output) {
     $output = basename($transcripts) . ".mm2.bam";
 }
 
-
 my $MINIMAP2_CUSTOM_OPTS = $ENV{MINIMAP2_CUSTOM_OPTS} || "";
 
 
-main: {
-
-	
+ main: {
 	my $genomeBaseDir = dirname($genome);
 	my $genomeName = basename($genome);
 	my $genomeDir = "$genomeBaseDir/$genomeName" . ".mm2";
-    
 
+    my $pipeliner = new Pipeliner("-checkpoint_dir" => $genomeDir, "-verbose" => 2);
+        
     unless (-d $genomeDir) {
         &process_cmd("mkdir $genomeDir");
     }
@@ -90,22 +93,19 @@ main: {
         $splice_file = "$genomeDir/anno.bed";
     }
 
+    my $minimap2_cmd = "minimap2 -d $mm2_idx $genome";
+    my $minimap2_chckpt = "${mm2_idx}.ok";
 
-    unless (-e $mm2_idx) {
-        
-        my $cmd = "minimap2 -d $mm2_idx $genome";
-        &process_cmd($cmd);
+    unless (-e $minimap2_chckpt) {
+        $pipeliner->add_commands(new Command($minimap2_cmd, $minimap2_chckpt));
+        $pipeliner->run();
 
         if ($gtf) {
             my $cmd = "paftools.js gff2bed $gtf > $splice_file";
             &process_cmd($cmd);
         }
-	
     }
     
-	
-	## run minimap2
-
     my $splice_param = "";
     if ($splice_file) {
         $splice_param = "--junc-bed $splice_file";


### PR DESCRIPTION
I had a situation where my pipeline failed while running, and in the logs I see it was during minimap2 execution.  Thinking it was re-run safe, I re-ran the command and this time had some monitoring terminals up so I could watch resource usage.  To my surprise, it skipped right past the minimap2 step and carried on with the rest of the pipeline. 

Checking the code, I see this was because it was only checking for the presence of the minimap2 output file and not actually seeing if it finished (mine was running out of RAM and dying.)

I've fixed this to use your pipeline module for at least that step.